### PR TITLE
better memory management; added multistage preselection

### DIFF
--- a/Mods/interface/FastJetMod.h
+++ b/Mods/interface/FastJetMod.h
@@ -33,13 +33,9 @@ namespace mithep
       //~FastJetMod();
 
       const char *GetOutputJetsName()     const { return fOutputJetsName;     }
-      const char *GetOutputFatJetsName()  const { return fOutputFatJetsName;  }
 
-      void MakeSmallJets(Bool_t b)              { fMakeSmallJets = b;         }
-      void MakeFatJets(Bool_t b)                { fMakeFatJets = b;           }
       void GetMatchBtag(Bool_t b)               { fGetMatchBtag = b;          }
       void UseBambuJets(Bool_t b)               { fUseBambuJets = b;          }
-      void UseBambuFatJets(Bool_t b)            { fUseBambuFatJets = b;       }
 
       void SetBtaggedJetsName(const char *n)    { fBtaggedJetsName = n;       }
       void SetBtaggedJetsFromBranch(Bool_t b)   { fBtaggedJetsFromBranch = b; }
@@ -47,18 +43,15 @@ namespace mithep
       void SetJetsName(const char *n)           { fJetsName = n;              }
       void SetJetsFromBranch(Bool_t b)          { fJetsFromBranch = b;        }
                                                                               
-      void SetFatJetsName(const char *n)        { fFatJetsName = n;           }
-      void SetFatJetsFromBranch(Bool_t b)       { fFatJetsFromBranch = b;     }
-
       void SetPfCandidatesName(const char *n)   { fPfCandidatesName = n;      }
       void SetPfCandidatesFromBranch(Bool_t b)  { fPfCandidatesFromBranch = b;}
 
       void SetOutputJetsName(const char *n)     { fOutputJetsName = n;        }
-      void SetOutputFatJetsName(const char *n)  { fOutputFatJetsName = n;     }
                                                                     
       void SetConeSize(double d)                { fJetConeSize = d;           }
-      void SetFatConeSize(double d)             { fFatJetConeSize = d;        }
 
+      void SetParticleMinPt(double d)           { fParticleMinPt = d;         }
+      void SetJetMinPt(double d)                { fJetMinPt = d;              }
  
     protected:
       void Process();
@@ -69,8 +62,6 @@ namespace mithep
       void FillPFJet (PFJet *pPFJet, fastjet::PseudoJet &fjJet);    
         
     private:
-      Bool_t fMakeSmallJets;               //=true if small cone jets collections active
-      Bool_t fMakeFatJets;                 //=true if large cone jets collections active
       Bool_t fGetMatchBtag;                //=true if b-tag obtained by match with standard jets (AK5)
       Bool_t fUseBambuJets;                //=true if input small jets already present in bambu
       Bool_t fUseBambuFatJets;             //=true if input large jets already present in bambu
@@ -83,19 +74,12 @@ namespace mithep
       Bool_t fJetsFromBranch;              //are input jets from Branch?
       const PFJetCol *fJets;               //input jets
 
-      TString fFatJetsName;                //(i) name of input fat jets
-      Bool_t fFatJetsFromBranch;           //are input fat jets from Branch?
-      const PFJetCol *fFatJets;            //input fat jets
-
       TString fPfCandidatesName;           //(i) name of PF candidates coll
       Bool_t fPfCandidatesFromBranch;      //are PF candidates from Branch?
       const PFCandidateCol *fPfCandidates; //particle flow candidates coll handle
  
       TString fOutputJetsName;             //name of output jets collection
-      JetOArr *fOutputJets;              //output jets collection
-
-      TString fOutputFatJetsName;          //name of output fat jets collection
-      JetOArr *fOutputFatJets;           //output fat jets collection
+      JetOArr *fOutputJets;                //output jets collection
       
       // Objects from fastjet we want to use
       double fJetConeSize;                 //fastjet clustering radius
@@ -104,6 +88,9 @@ namespace mithep
       fastjet::JetDefinition *fAKFatJetDef;//fastjet fat clustering definition
       fastjet::GhostedAreaSpec *fActiveArea;
       fastjet::AreaDefinition *fAreaDefinition;
+
+      double fParticleMinPt;               //low cutoff to avoid including unphysical PFCands
+      double fJetMinPt;                    //low cutoff to carrying on soft jets
       
       ClassDef(FastJetMod, 0)              //FastJet bambu producer      
   };

--- a/SelMods/src/BoostedVAnalysisMod.cc
+++ b/SelMods/src/BoostedVAnalysisMod.cc
@@ -323,16 +323,17 @@ void BoostedVAnalysisMod::Process()
 
   if (fApplyGjetPresel) {
     // G+jets Preselection: require boosted jet + photon
-    int nGoodTagJets = 0;
+    int nGoodFatJets = 0;
     int nGoodPhotons = 0;
 
-    // Jets
-    for (UInt_t i = 0; i < fJets->GetEntries(); ++i) {
-      const Jet *jet = fJets->At(i);
-      // Pt and eta cuts
-      if (jet->Pt() < fMinTagJetPt || fabs(jet->Eta()) > 2.5)
-        continue;
-      nGoodTagJets++;
+    // FatJets
+    if (fFatJets->GetEntries() > 0) { 
+      for (UInt_t i = 0; i < fFatJets->GetEntries(); ++i) {
+        const Jet *jet = fFatJets->At(i);
+        // Pt and eta cuts
+        if (jet->Pt() < fMinFatJetPt || fabs(jet->Eta()) > 2.5)
+          nGoodFatJets++;
+      }
     }
 
     // Photons
@@ -345,7 +346,7 @@ void BoostedVAnalysisMod::Process()
         nGoodPhotons++;
       }
     }
-    if (nGoodTagJets > 0 && nGoodPhotons > 0)
+    if (nGoodFatJets > 0 && nGoodPhotons > 0)
       passGjetPresel = kTRUE;
   }
 
@@ -357,15 +358,17 @@ void BoostedVAnalysisMod::Process()
   }
 
   // Store the preselection word in the extended event selection object
-  int preselectionWord = GetPreselWord (
-                         passTopPresel, 
-                         passWlepPresel,
-                         passZlepPresel,
-                         passMetPresel, 
-                         passVbfPresel, 
-                         passGjetPresel); 
-  fXlEvtSelData->SetFiltersWord(fEvtSelData->metFiltersWord());
-  fXlEvtSelData->SetPreselWord(preselectionWord);
+  if (fFillAndPublishPresel) {
+    int preselectionWord = GetPreselWord (
+                           passTopPresel, 
+                           passWlepPresel,
+                           passZlepPresel,
+                           passMetPresel, 
+                           passVbfPresel, 
+                           passGjetPresel); 
+    fXlEvtSelData->SetFiltersWord(fEvtSelData->metFiltersWord());
+    fXlEvtSelData->SetPreselWord(preselectionWord);
+  }
    
   // Increment passed events counter
   fPass++;


### PR DESCRIPTION
This pull improves memory allocation for fast jet dependent modules.
It also add a multistage preselection to reduce event processing time 
before doing full-blown jet reclustering.
Finally, JEC are updated to large cone CHS (AK7chs, the best available 
proxy according to JET MET).
